### PR TITLE
Added order_ts on semantic orders_v

### DIFF
--- a/scripts/setup.sql
+++ b/scripts/setup.sql
@@ -507,6 +507,7 @@ SELECT * FROM (
     SELECT
         order_id::VARCHAR AS order_id,
         truck_id::VARCHAR AS truck_id,
+        order_ts::DATE as order_ts,
         order_detail_id::VARCHAR AS order_detail_id,
         truck_brand_name,
         menu_type,

--- a/scripts/setup.sql
+++ b/scripts/setup.sql
@@ -507,7 +507,7 @@ SELECT * FROM (
     SELECT
         order_id::VARCHAR AS order_id,
         truck_id::VARCHAR AS truck_id,
-        order_ts::DATE as order_ts,
+        order_ts::DATE AS order_ts,
         order_detail_id::VARCHAR AS order_detail_id,
         truck_brand_name,
         menu_type,

--- a/semantic_models/TASTY_BYTES_BUSINESS_ANALYTICS.yaml
+++ b/semantic_models/TASTY_BYTES_BUSINESS_ANALYTICS.yaml
@@ -534,7 +534,7 @@ tables:
           - '278'
           - '400'
     time_dimensions:
-      - name: ORDER_DATE
+      - name: ORDER_TS
         synonyms:
           - order_timestamp
           - order_creation_date
@@ -543,7 +543,7 @@ tables:
           - order_receipt_date
           - order_datetime
         description: Date on which the order was placed.
-        expr: ORDER_DATE
+        expr: ORDER_TS
         data_type: DATE
         sample_values:
           - '2021-12-20'


### PR DESCRIPTION
Hi,

I was following the Zero to Snowflake quickstart guide, but got stuck on [step 20](https://quickstarts.snowflake.com/guide/zero_to_snowflake/index.html?index=..%2F..index#19). After following the instuctions, The first prompt would give the following error:

Prompt:
"Show customer groups by marital status and gender, with their total spending per customer and average order value. Break this down by city and region, and also include the year of the orders so I can see when the spending occurred. In addition to the yearly breakdown, calculate each group's total lifetime spending and their average order value across all years. Rank the groups to highlight which demographics spend the most per year and which spend the most overall."

Response:
"I apologize, but the question cannot be answered completely because the semantic data model does not include a date or year dimension for orders. While I can analyze customer groups by marital status and gender with their spending patterns, and break this down by city and region, I cannot provide the yearly breakdown or show when the spending occurred since there are no date fields available in the order data."

After inspecting the created dimensions, I noticed there was indeed no dimension representing the order dimensions. Because these dimensions were initially created automatically based on the table columns, adding the `order_ts` column to the table allows the dimension to be dynamically created, allowing the prompt to work correctly.

I've also updated the semantic yaml accordingly, to reflect these changes.